### PR TITLE
Adds input 'num' to MEX file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Temporary Items
 *.mex*
 
 *.asv
+*.mexw64

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Temporary Items
 # MEX-file binaries
 *.mex*
 
+*.asv

--- a/myo_2c_sfunc.cpp
+++ b/myo_2c_sfunc.cpp
@@ -9,6 +9,9 @@
 #include <string>
 #include "myo_class2a.hpp"
 
+#define NUM_DEF 1
+#define NUM_MAX 12000UL
+
 DataCollector dataCollector;
 
  
@@ -46,7 +49,26 @@ mxArray *create_fill_EMG (const std::array<int8_t, 8> emgData)
  
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-     
+  long int num = NUM_DEF; // default value for input num
+  
+  // handle optional input num
+  if ( nrhs>0 ) { // user input value for num
+    // check for valid input type and size
+    if( !mxIsDouble(prhs[0]) || mxIsComplex(prhs[0]) ||
+        !(mxGetM(prhs[0])==1 && mxGetM(prhs[0])==1) )
+      mexErrMsgTxt("Input num must be a real numeric scalar.");
+    // get the input value
+    num = *mxGetPr(prhs[0]); // implicit cast to integer value
+    // check for valid input value
+    if (num<1 || num>NUM_MAX)
+      mexErrMsgTxt("Input num is out of range.");
+  }
+  
+  // check number of output arguments
+  if(nlhs > 1){
+    mexErrMsgTxt("Too many output arguments.");
+  }
+  
     myo::Hub hUb("com.example.hello-myo"); 
 	hUb.addListener(&dataCollector);
     myo::Myo* mYo = hUb.waitForMyo(10);
@@ -80,7 +102,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     plhs[0] = mxCreateStructMatrix (1, 1, frame_fields, frame_field_names);
     
     int counter=0;
-    int mRow=12000;
+    int mRow=num;//12000;
     
     const mwSize dims[]={mRow,1};
     const mwSize dimsV[]={mRow,3};
@@ -100,14 +122,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     mxArray *mxaCounter = mxCreateNumericArray (2, dims, mxDOUBLE_CLASS, mxREAL); 
     mxArray *mxgCounter = mxCreateNumericArray (2, dims, mxDOUBLE_CLASS, mxREAL); 
     
-    /* Check for proper number of input and  output arguments */    
-    if (nrhs !=0) {
-        mexErrMsgTxt("No input argument required.");
-    } 
-    if(nlhs > 1){
-        mexErrMsgTxt("Too many output arguments.");
-    }
-
+    
 //     int counter=1;
 //     // Finally we enter our main loop.
  

--- a/myo_2c_sfunc.m
+++ b/myo_2c_sfunc.m
@@ -1,0 +1,34 @@
+% MYO_2C_SFUNC(NUM)  Poll Myo for NUM samples
+%   This MEX function collects Myo data by polling with best-effort
+%   approach to collect NUM samples. Data is returned in a single struct
+%   output variable.
+%
+% Usage:
+%   F = myo_2c_sfunc()
+%     Returns one data sample from Myo in output struct F.
+%
+%   F = myo_2c_sfunc(num)
+%     Same as above, but returns num samples in scalar output struct F.
+%     Note that if input num is not provided, the default is 1.
+%
+% Inputs
+%   num (optional)
+%     Number of samples to collect from Myo. The default value is 1.
+%
+% Outputs
+%   F
+%     Structure containing vectors of Myo data samples with the following
+%     fields
+%   F.Roll        TODO
+%   F.Pitch       TODO
+%   F.Yaw         TODO
+%   F.accData     TODO
+%   F.gyroData    TODO
+%   F.emgData     TODO
+%   F.onArm       TODO
+%   F.isUnlocked  TODO
+%   F.onWhichArm  TODO
+%   F.whichPose   TODO
+%   F.eCounter    TODO
+%   F.aCounter    TODO
+%   F.gCounter    TODO

--- a/test_matMyo.m
+++ b/test_matMyo.m
@@ -2,9 +2,20 @@
  
  clear
  clc
- f=myo_2c_sfunc ;
+ % f=myo_2c_sfunc;         % default one sample
+ % f=myo_2c_sfunc(1);      % explicit one sample
+ f=myo_2c_sfunc(10000);
  
- 
+  
+% Input error cases
+% [~,~] = myo_2c_sfunc; % too many outputs
+% myo_2c_sfunc({}); % bad data type
+% myo_2c_sfunc(''); % bad data type
+% myo_2c_sfunc(struct); % bad data type
+% myo_2c_sfunc(0); % bad value
+% myo_2c_sfunc(-1); % bad value
+% myo_2c_sfunc(1e8); % bad value
+
  
  %%
 [~, ind]=unique(f.eCounter);  


### PR DESCRIPTION
Caller optionally specifies the number of samples desired from Myo in input num. Implements input type and value bounds checking.
